### PR TITLE
fix: add workaround for wrong config file extension on some browsers

### DIFF
--- a/web/src/shared/utils/downloadWGConfig.ts
+++ b/web/src/shared/utils/downloadWGConfig.ts
@@ -2,7 +2,9 @@ import saveAs from 'file-saver';
 
 export const downloadWGConfig = (config: string, fileName: string) => {
   const blob = new Blob([config.replace(/^[^\S\r\n]+|[^\S\r\n]+$/gm, '')], {
-    type: 'text/plain;charset=utf-8',
+    // octet-stream is used here as a workaround: some browsers will append 
+    // an additional .txt extension to the file name if the MIME type is text/plain.
+    type: 'application/octet-stream;charset=utf-8',
   });
   saveAs(blob, `${fileName.toLowerCase()}.conf`);
 };

--- a/web/src/shared/utils/downloadWGConfig.ts
+++ b/web/src/shared/utils/downloadWGConfig.ts
@@ -2,9 +2,9 @@ import saveAs from 'file-saver';
 
 export const downloadWGConfig = (config: string, fileName: string) => {
   const blob = new Blob([config.replace(/^[^\S\r\n]+|[^\S\r\n]+$/gm, '')], {
-    // octet-stream is used here as a workaround: some browsers will append 
+    // octet-stream is used here as a workaround: some browsers will append
     // an additional .txt extension to the file name if the MIME type is text/plain.
-    type: 'application/octet-stream;charset=utf-8',
+    type: 'application/octet-stream',
   });
   saveAs(blob, `${fileName.toLowerCase()}.conf`);
 };


### PR DESCRIPTION
The issue is described in more detail in https://github.com/DefGuard/defguard/issues/600

Corresponding PR addressing this issue in the core can be found here: https://github.com/DefGuard/defguard/pull/638