### PR TITLE
feat: properly interpret forbidden error codes 

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub enum ApiError {
     CoreTimeout,
     #[error("Invalid core gRPC response type received")]
     InvalidResponseType,
+    #[error("PermissionDenied")]
+    PermissionDenied,
 }
 
 impl IntoResponse for ApiError {
@@ -30,6 +32,7 @@ impl IntoResponse for ApiError {
         let (status, error_message) = match self {
             Self::Unauthorized => (StatusCode::UNAUTHORIZED, self.to_string()),
             Self::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
+            Self::PermissionDenied => (StatusCode::FORBIDDEN, self.to_string()),
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Internal server error".to_string(),
@@ -51,6 +54,7 @@ impl From<CoreError> for ApiError {
         match status.code() {
             Code::Unauthenticated => ApiError::Unauthorized,
             Code::InvalidArgument => ApiError::BadRequest(status.message().to_string()),
+            Code::PermissionDenied => ApiError::PermissionDenied,
             _ => ApiError::Unexpected(status.to_string()),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,7 @@ pub enum ApiError {
     CoreTimeout,
     #[error("Invalid core gRPC response type received")]
     InvalidResponseType,
-    #[error("PermissionDenied")]
+    #[error("Permission denied")]
     PermissionDenied,
 }
 


### PR DESCRIPTION
## 📖 Description

Core can return a forbidden error code during the enrollment. This change makes it so it's not converted into an internal server error.

### 🛠️ Dev Branch Merge Checklist:

#### Documentation ###

- [x] If testing requires changes in the environment or deployment, please **update the documentation** (https://defguard.gitbook.io) first and **attach the link to the documentation** section in this pool request
- [x] I have commented on my code, particularly in hard-to-understand areas

#### Testing ### 

- [x] I have prepared end-to-end tests for all new functionalities
- [x] I have performed end-to-end tests manually and they work
- [x] New and existing unit tests pass locally with my changes

#### Deployment ###

- [x] If deployment is affected I have made corresponding/required changes to [deployment](https://github.com/defguard/deployment) (Docker, Kubernetes, one-line install)

### 🏚️ Main Branch Merge Checklist:

#### Testing ### 

- [ ] I have merged my changes before to dev and the dev checklist is done
- [ ] I have tested all functionalities on the dev instance and they work

#### Documentation ###

- [ ] I have made corresponding changes to the **user & admin documentation** and added new features documentation with screenshots for users/admins
