### PR TITLE
Make client IP mandatory

### DIFF
--- a/src/handlers/enrollment.rs
+++ b/src/handlers/enrollment.rs
@@ -39,9 +39,10 @@ async fn start_enrollment_process(
     let token = req.token.clone();
 
     debug!("Sending the enrollment process request to core service.");
-    let rx = state
-        .grpc_server
-        .send(Some(core_request::Payload::EnrollmentStart(req)), device_info)?;
+    let rx = state.grpc_server.send(
+        Some(core_request::Payload::EnrollmentStart(req)),
+        device_info,
+    )?;
     let payload = get_core_response(rx).await?;
     debug!("Receving payload from the core service. Try to set private cookie for starting enrollment process.");
     if let core_response::Payload::EnrollmentStart(response) = payload {

--- a/src/handlers/enrollment.rs
+++ b/src/handlers/enrollment.rs
@@ -23,6 +23,7 @@ pub(crate) fn router() -> Router<AppState> {
 #[instrument(level = "debug", skip(state))]
 async fn start_enrollment_process(
     State(state): State<AppState>,
+    device_info: Option<DeviceInfo>,
     mut private_cookies: PrivateCookieJar,
     Json(req): Json<EnrollmentStartRequest>,
 ) -> Result<(PrivateCookieJar, Json<EnrollmentStartResponse>), ApiError> {
@@ -40,7 +41,7 @@ async fn start_enrollment_process(
     debug!("Sending the enrollment process request to core service.");
     let rx = state
         .grpc_server
-        .send(Some(core_request::Payload::EnrollmentStart(req)), None)?;
+        .send(Some(core_request::Payload::EnrollmentStart(req)), device_info)?;
     let payload = get_core_response(rx).await?;
     debug!("Receving payload from the core service. Try to set private cookie for starting enrollment process.");
     if let core_response::Payload::EnrollmentStart(response) = payload {


### PR DESCRIPTION
Updates proxy to treat the retrieval of the client IP address as mandatory rather than optional.

Previously, the server allowed for the client IP to be omitted, under the assumption that it may not always be retrievable. However, in practice, the inability to obtain the client IP can only occur in case of misconfiguration. Treating the IP as optional was masking these configuration issues instead of surfacing them appropriately.

By making the client IP mandatory we align the protobuf data structure constraints with the actual expectations and ensure that upstream systems relying on this metadata receive consistent and complete information.