### PR TITLE
Ignore pre-release in version comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
 [[package]]
 name = "defguard_version"
 version = "0.0.0"
-source = "git+https://github.com/DefGuard/defguard.git?rev=c8e1bc91e0410a91af0b124d2d2b57c5a7226517#c8e1bc91e0410a91af0b124d2d2b57c5a7226517"
+source = "git+https://github.com/DefGuard/defguard.git?rev=8649a9ba225d7bd2066a09c9e1347705c34bd158#8649a9ba225d7bd2066a09c9e1347705c34bd158"
 dependencies = [
  "axum",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/DefGuard/proxy"
 repository = "https://github.com/DefGuard/proxy"
 
 [dependencies]
-defguard_version = { git = "https://github.com/DefGuard/defguard.git", rev = "c8e1bc91e0410a91af0b124d2d2b57c5a7226517" }
+defguard_version = { git = "https://github.com/DefGuard/defguard.git", rev = "8649a9ba225d7bd2066a09c9e1347705c34bd158" }
 # base `axum` deps
 axum = { version = "0.8", features = ["ws"] }
 axum-client-ip = "0.7"


### PR DESCRIPTION
Fixes version comparison by ignoring pre-release semver field.