### PR TITLE
Cookie key proto

### DIFF
--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -256,16 +256,16 @@ impl proxy_server::Proxy for ProxyServer {
         //     }
         // };
 
-		error!("### WAITING for key");
+        error!("### WAITING for key");
         let mut stream = request.into_inner();
         let key = match stream.message().await {
             Ok(Some(response)) => match response.payload {
                 Some(core_response::Payload::InitialInfo(payload)) => {
-					error!("### got the key");
-					Key::from(&payload.private_cookies_key)
-				}
-				Some(_) => todo!(),
-				None => todo!(),
+                    error!("### got the key");
+                    Key::from(&payload.private_cookies_key)
+                }
+                Some(_) => todo!(),
+                None => todo!(),
             },
             Ok(None) => {
                 info!("gRPC stream has been closed");
@@ -277,7 +277,7 @@ impl proxy_server::Proxy for ProxyServer {
             }
         };
 
-		error!("### KEY: {:?}", key.master());
+        error!("### KEY: {:?}", key.master());
         self.http_channel.send(key).map_err(|err| {
             error!("Failed to send private cookies key to HTTP server: {err:?}");
             Status::internal("Failed to send private cookies key to HTTP server")

--- a/src/http.rs
+++ b/src/http.rs
@@ -229,7 +229,6 @@ pub async fn run_server(config: Config) -> anyhow::Result<()> {
             debug!("Creating certs directory");
             tokio::fs::create_dir_all(cert_dir).await?;
         }
-        debug!("DONE");
 
         loop {
             let server_to_run = server_clone.clone();

--- a/src/http.rs
+++ b/src/http.rs
@@ -196,10 +196,10 @@ pub async fn run_server(config: Config) -> anyhow::Result<()> {
     tasks.spawn(async move {
         let cert_dir = Path::new(&config.cert_dir);
         if !cert_dir.exists() {
-			debug!("Creating certs directory");
+            debug!("Creating certs directory");
             tokio::fs::create_dir_all(cert_dir).await?;
         }
-		debug!("DONE");
+        debug!("DONE");
 
         loop {
             let server_to_run = server_clone.clone();

--- a/src/http.rs
+++ b/src/http.rs
@@ -196,8 +196,10 @@ pub async fn run_server(config: Config) -> anyhow::Result<()> {
     tasks.spawn(async move {
         let cert_dir = Path::new(&config.cert_dir);
         if !cert_dir.exists() {
+			debug!("Creating certs directory");
             tokio::fs::create_dir_all(cert_dir).await?;
         }
+		debug!("DONE");
 
         loop {
             let server_to_run = server_clone.clone();


### PR DESCRIPTION
Core sends InitialInfo message immediately after connecting to proxy. The message contains private cookies key to be used by all proxy instances.