### PR TITLE
include lsb_release in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN cargo install --locked --path . --root /build
 # run
 FROM debian:13-slim AS runtime
 RUN apt-get update -y && apt upgrade -y && \
-    apt-get install --no-install-recommends -y ca-certificates libssl-dev && \
+    apt-get install --no-install-recommends -y ca-certificates libssl-dev lsb-release && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=builder /build/bin/defguard-proxy .


### PR DESCRIPTION
Include tool required for version reporting in the Docker image.

Closes https://github.com/DefGuard/proxy/issues/236 