### PR TITLE
update trivyignore for unpatched CVEs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Scan code with Trivy
         uses: aquasecurity/trivy-action@v0.36.0
         env:
-          TRIVY_IGNOREFILE: ".trivyignore.yaml"
+          TRIVY_IGNOREFILE: "./.trivyignore.yaml"
           TRIVY_SHOW_SUPPRESSED: 1
         with:
           scan-type: 'fs'

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -2,3 +2,9 @@ vulnerabilities:
   - id: GHSA-w5hq-g745-h8pq
     expired_at: 2026-05-23
     statement: "Waiting for upstream patch in paraglide"
+  - id: CVE-2026-29111
+    expired_at: 2026-05-31
+    statement: "No fixed version available in debian:13-slim - waiting for Debian to backport systemd patch"
+  - id: CVE-2025-69720
+    expired_at: 2026-05-31
+    statement: "No fixed version available in debian:13-slim - waiting for Debian to release ncurses patch"


### PR DESCRIPTION
Add entries for vulnerabilities which are unpatched in the upstream Debian image with no fixed version available yet.